### PR TITLE
settings_file_path as .json

### DIFF
--- a/flask_sso_saml/ext.py
+++ b/flask_sso_saml/ext.py
@@ -22,6 +22,10 @@ from ._compat import string_types
 from .utils import SAMLAuth, prepare_flask_request
 from .views import create_blueprint
 
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 def _default_config(idp):
     """Default IdP configuration."""
@@ -194,9 +198,13 @@ class _FlaskSSOSAMLState(object):
 
         if config['settings_file_path']:
             with open(config['settings_file_path'], 'r') as idp:
-                external_conf = OneLogin_Saml2_IdPMetadataParser.parse(
-                    idp.read()
-                )
+                file = config['settings_file_path']
+                # xml format
+                if file.endswith('.xml'):
+                    external_conf = OneLogin_Saml2_IdPMetadataParser.parse(idp.read())
+                # json format
+                elif file.endswith('.json'):
+                    external_conf = json.loads(idp.read())
             config['settings']['idp'].update(external_conf.get('idp'))
 
         # Load certificate and key


### PR DESCRIPTION
As mentioned on issue [#8](https://github.com/inveniosoftware/invenio-saml/issues/8) of ```invenio-saml```.
loading from files was currently working only for ```xml``` extension/format.
## Changes i made
added a condition to check also for ```.json``` extension/format, once it finds then it reads it and updates the ```idp``` configuration.

## Test on loading from files
also tested these other two files loading, which works just fine.
```
        if config['sp_cert_file']:
            with open(config['sp_cert_file'], 'r') as cf:
                cert = cf.read()
            config['settings']['sp']['x509cert'] = cert

        if config['sp_key_file']:
            with open(config['sp_key_file'], 'r') as cf:
                cert = cf.read()
            config['settings']['sp']['privateKey'] = cert
```

with these configurations on my ```invenio.cfg```.
```
SSO_SAML_IDPS = {
	'onelogin': {
		# settings_file_path can be either json or xml.
		"settings_file_path": "./saml/onelogin/onelogin.json",
		"sp_cert_file": "./saml/onelogin/cert/sp.crt",			
		"sp_key_file": "./saml/onelogin/cert/sp.key",		
	       ........}}
```
 